### PR TITLE
feat: integrate journal apis in frontend

### DIFF
--- a/MindMate-FE/src/components/dashboard/mood-tracker.tsx
+++ b/MindMate-FE/src/components/dashboard/mood-tracker.tsx
@@ -6,7 +6,8 @@ import { Button } from "@/components/ui/button"
 import { Slider } from "@/components/ui/slider"
 import { createMoodLog } from "@/services/moodService"
 
-const moodEmojis = ["😢", "😕", "😐", "😊", "😄"]
+const moodEmojis = ["😔", "😢", "😐", "😁", "🤩"]
+
 const moodLabels = ["Very Sad", "Sad", "Neutral", "Happy", "Very Happy"]
 
 interface MoodTrackerProps {

--- a/MindMate-FE/src/components/dashboard/quick-journal.tsx
+++ b/MindMate-FE/src/components/dashboard/quick-journal.tsx
@@ -5,7 +5,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Sparkles, Send } from "lucide-react"
-import { createJournalEntry } from "@/services/journalService"
+import { createQuickJournalEntry } from "@/services/journalService"
 
 const journalPrompts = [
   "What made you smile today?",
@@ -34,7 +34,7 @@ export default function QuickJournal() {
   setIsSubmitting(true)
 
   try {
-    await createJournalEntry({
+    await createQuickJournalEntry({
       description: entry,
       title: currentPrompt,
     })

--- a/MindMate-FE/src/components/journal/journal-entry.tsx
+++ b/MindMate-FE/src/components/journal/journal-entry.tsx
@@ -27,7 +27,8 @@ export default function JournalEntry({ entry, index }: JournalEntryProps) {
           <div className="flex items-center space-x-4 text-sm text-gray-600">
             <div className="flex items-center space-x-1">
               <Calendar className="h-4 w-4" />
-              <span>{entry.date.toLocaleDateString()}</span>
+              <span>{new Date(entry.date).toLocaleDateString()}</span>
+
             </div>
             <div className="flex items-center space-x-1">
               <span className="text-lg">{entry.mood.emoji}</span>

--- a/MindMate-FE/src/components/journal/new-entry-modal.tsx
+++ b/MindMate-FE/src/components/journal/new-entry-modal.tsx
@@ -5,8 +5,9 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Slider } from "@/components/ui/slider"
+import { createJournalEntry } from "@/services/journalService"
 
-const moodEmojis = ["😢", "😕", "😐", "😊", "😄"]
+const moodEmojis = ["😔", "😢", "😐", "😁", "🤩"]
 const suggestions = [
   "What made you smile today?",
   "What are you grateful for?",
@@ -29,22 +30,21 @@ export default function NewEntryModal({ isOpen, onClose, onSave }: NewEntryModal
   const [tags, setTags] = useState("")
   const [currentSuggestion, setCurrentSuggestion] = useState(suggestions[0])
 
-  const handleSave = () => {
+  const handleSave =async () => {
     if (!title.trim() || !content.trim()) return
 
     const entry = {
       title: title.trim(),
-      content: content.trim(),
-      mood: {
-        emoji: moodEmojis[mood - 1],
-        value: mood,
-      },
+      description: content.trim(),
+      mood: mood, 
       tags: tags
         .split(",")
         .map((tag) => tag.trim())
         .filter(Boolean),
     }
 
+    const data=await createJournalEntry(entry);
+    console.log(data)
     onSave(entry)
 
     // Reset form

--- a/MindMate-FE/src/context/AuthProvider.tsx
+++ b/MindMate-FE/src/context/AuthProvider.tsx
@@ -25,7 +25,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const login = async (email: string, password: string) => {
     try {
       const { access_token, refresh_token } = await loginUser(email, password)
-
+      console.log(access_token, refresh_token)
       if (access_token && refresh_token) {
         localStorage.setItem("access_token", access_token)
         localStorage.setItem("refresh_token", refresh_token)

--- a/MindMate-FE/src/pages/Journal.tsx
+++ b/MindMate-FE/src/pages/Journal.tsx
@@ -1,10 +1,11 @@
 import { motion } from "framer-motion"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { ArrowLeft, Plus, Calendar, Heart, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useNavigate } from "react-router-dom"
 import JournalEntry from "@/components/journal/journal-entry"
 import NewEntryModal from "@/components/journal/new-entry-modal"
+import { getAllJournalEntries } from "@/services/journalService"
 
 // Mock journal entries - to be replaced with backend integration
 const mockEntries = [
@@ -37,20 +38,70 @@ const mockEntries = [
   },
 ]
 
+const moodEmojis = [
+  { emoji: "😔", value: 1 },
+  { emoji: "😐", value: 2 },
+  { emoji: "😊", value: 3 },
+  { emoji: "😁", value: 4 },
+  { emoji: "🤩", value: 5 },
+];
+
 export default function JournalPage() {
   const [entries, setEntries] = useState(mockEntries)
+  const [loading, setLoading] = useState(true)
   const [showNewEntry, setShowNewEntry] = useState(false)
   const navigate = useNavigate()
+  useEffect(() => {
+  const fetchEntries = async () => {
+    try {
+      const data = await getAllJournalEntries()
+      console.log("theses are entries",data)
+      const formattedEntries = data.map((entry: any) => {
+  const moodIndex = entry.mood ? entry.mood - 1 : null;
+  const mood =
+    moodIndex !== null && moodEmojis[moodIndex]
+      ? moodEmojis[moodIndex]
+      : { emoji: "❓", value: 1 };
 
-  const handleNewEntry = (entry: any) => {
-    const newEntry = {
-      id: Date.now().toString(),
-      ...entry,
-      date: new Date(),
+  return {
+    id: entry.id,
+    title: entry.title,
+    content: entry.description,
+    mood,
+    date: new Date(entry.created_at),
+    tags: entry.tags ?? [],
+  };
+});
+setEntries(formattedEntries);
+console.log("hello",formattedEntries)
+
+     
+    } catch (error) {
+      console.error("Failed to fetch journal entries", error)
+    } finally {
+      setLoading(false)
     }
-    setEntries((prev) => [newEntry, ...prev])
   }
 
+  fetchEntries()
+}, [])
+
+  const handleNewEntry = (entry: any) => {
+    // const newEntry = {
+    //   id: Date.now().toString(),
+    //   ...entry,
+    //   date: new Date(),
+    // }
+    // setEntries((prev) => [newEntry, ...prev])
+     window.location.reload();
+  }
+    if (loading) {
+    return (
+      <div className="flex justify-center items-center h-full p-4">
+        <div className="loader">Loading...</div>
+      </div>
+    )
+  }
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-teal-50">
       {/* Header */}

--- a/MindMate-FE/src/services/journalService.ts
+++ b/MindMate-FE/src/services/journalService.ts
@@ -1,7 +1,14 @@
 // src/services/journalService.ts
 import api from "@/api/axios"
 
-export const createJournalEntry = async ({
+interface JournalEntryInput {
+  title: string
+  description: string
+  mood: number
+  tags: string[]
+}
+
+export const createQuickJournalEntry = async ({
   title,
   description,
 }: {
@@ -14,5 +21,10 @@ export const createJournalEntry = async ({
 
 export const getAllJournalEntries = async () => {
   const response = await api.get("/journal/")
+  return response.data
+}
+
+export const createJournalEntry = async (entry:JournalEntryInput) => {
+  const response = await api.post("/journal/", entry)
   return response.data
 }


### PR DESCRIPTION
# ✨ Journal Service Integration & Quick Journal Enhancement

## 🔧 What’s Added / Changed

### 1. Created `journalService.ts`
- Added API functions:
  - `getAllJournalEntries` – fetches all journal entries from backend
  - `createJournalEntry` – creates a new journal entry with title, description, mood, and tags
- Defined a `JournalEntryInput` TypeScript interface to enforce consistent payload structure

### 2. Connected Frontend to Backend
- Hooked up backend APIs with frontend journal UI
- Journal entries now load dynamically from the backend
- New journal entries can be created and rendered immediately on the UI

### 3. Quick Journal Improvements
- Supports quick entry with just `title` and `description`
- Trimmed input values before submission
- Cleaned and parsed tags from comma-separated string
- Optional fields (`mood`, `tags`) gracefully handled

### 4. Mood Log Handling
- Added fallback values for `mood` when it's null (defaulting to `❓`)
- Prevented UI crashes on missing mood data

### 5. Refactored `createJournalEntry` function
- Now accepts a single `entry` object instead of separate fields
- Centralizes payload creation and avoids duplicate logic

---

## 🧠 Upcoming Enhancements

- **AI Integration for Quick Journal:**
  - AI will analyze the journal description to infer mood and suggest tags
  - Useful for fast journaling without manual input

---

## 🧪 How to Test

1. Visit the **Journal** page
2. ✅ Ensure entries load correctly from backend
3. ✅ Test creating full journal entries and quick entries
4. ✅ Verify `mood` fallback when not set
5. ✅ Check that tags are trimmed, split, and properly submitted

---

