### PR TITLE
fix: add authentication in conversation api

### DIFF
--- a/MindMate-BE/app/api/routes/conversations.py
+++ b/MindMate-BE/app/api/routes/conversations.py
@@ -4,30 +4,79 @@ from uuid import UUID
 from app.db import models
 from app.schemas import chat as schemas
 from app.db.database import get_db
+from app.dependencies.auth import get_current_user
+from app.db.models import User 
+from fastapi import HTTPException, status
 
 router = APIRouter(prefix="/conversations", tags=["conversations"])
 
 @router.get("/", response_model=list[schemas.ConversationOut])
-def list_conversations(user_id: UUID, db: Session = Depends(get_db)):
-    return db.query(models.Conversation).filter_by(user_id=user_id).all()
+def list_conversations(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    return db.query(models.Conversation).filter_by(user_id=current_user.id).all()
 
 @router.post("/", response_model=schemas.ConversationOut)
-def create_conversation(user_id: UUID, db: Session = Depends(get_db)):
-    convo = models.Conversation(user_id=user_id)
+def create_conversation(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    convo = models.Conversation(user_id=current_user.id)
     db.add(convo)
     db.commit()
     db.refresh(convo)
     return convo
 
+
+
+
 @router.patch("/{conversation_id}")
-def rename_conversation(conversation_id: UUID, title: str, db: Session = Depends(get_db)):
-    convo = db.query(models.Conversation).get(conversation_id)
+def rename_conversation(
+    conversation_id: UUID,
+    title: str,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user)
+):
+    convo = db.query(models.Conversation).filter_by(id=conversation_id).first()
+
+    if convo is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Conversation not found"
+        )
+
+    if convo.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to rename this conversation"
+        )
+
     convo.title = title
     db.commit()
     return {"message": "Renamed"}
 
+
+
 @router.delete("/{conversation_id}")
-def delete_conversation(conversation_id: UUID, db: Session = Depends(get_db)):
-    db.query(models.Conversation).filter_by(id=conversation_id).delete()
+def delete_conversation(
+    conversation_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user)
+):
+    convo = db.query(models.Conversation).filter_by(id=conversation_id).first()
+
+    if not convo:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Conversation not found"
+        )
+
+    if convo.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to delete this conversation"
+        )
+
+    db.delete(convo)
     db.commit()
+
     return {"message": "Deleted"}
+


### PR DESCRIPTION
# 🔐 Add Authentication to Conversation API

## ✨ Summary

This PR integrates user authentication into all Conversation-related API endpoints using JWT-based access tokens.

## ✅ Changes Made

- 🔒 Replaced `user_id` query param with `get_current_user()` dependency to extract user identity from the token.
- 🛡️ Secured the following routes:
  - `POST /conversation/` → Only authenticated users can create conversations.
  - `PATCH /conversation/{conversation_id}` → User must own the conversation to rename it.
  - `DELETE /conversation/{conversation_id}` → User must be the creator to delete.
- ❗ Differentiated error handling:
  - `403 Forbidden` → If the user is not the owner.
  - `404 Not Found` → If the conversation doesn’t exist.

## 🧪 Testing

- Verified valid tokens allow access to create/rename/delete only their own conversations.
- Confirmed invalid or missing tokens result in 401 Unauthorized.
- Checked proper error messages for unauthorized or non-existent conversation actions.

## 📌 Notes

- Token validation and user retrieval are handled centrally via `get_current_user`.
- Ensures stricter control over conversation-level operations by tying actions to user ownership.

---

Let me know if you'd like to include code snippets or link this to an issue/ticket!
